### PR TITLE
Object orrientated flip

### DIFF
--- a/lib/flip.php
+++ b/lib/flip.php
@@ -14,4 +14,9 @@ class ┻━┻ extends Exception
     {
         return "┬─┬";
     }
+    
+    public static function ノ（°□°ノ）()
+    {
+        throw new static();
+    }
 }


### PR DESCRIPTION
Though perhaps it defeats the very purposed of having a `（╯°□°）╯︵┻━┻()` library.

Usage:

```
┻━┻::ノ（°□°ノ）();
```
